### PR TITLE
Fix flexparser FIPS mode

### DIFF
--- a/flexparser/flexparser.py
+++ b/flexparser/flexparser.py
@@ -280,7 +280,7 @@ class Hash:
         ],
         b: bytes,
     ) -> Self:
-        hasher = algorithm(b)
+        hasher = algorithm(b, usedforsecurity=False)
         return cls(hasher.name, hasher.hexdigest())
 
     @classmethod


### PR DESCRIPTION
With FIPS mode the following error is thrown.
`ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS`

Also, do I need to update anything [here](https://github.com/hgrecco/pint/blob/master/pint/_vendor/flexparser.py#L259) or is that pulled in?