### PR TITLE
Include flexparser.testsuite in the list of packages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ flexparser Changelog
 0.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add `flexparser.testsuite` to the list of packages in `pyproject.toml`.
 
 
 0.3 (2024-03-08)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ flexparser = ["py.typed"]
 Homepage = "https://github.com/hgrecco/flexparser"
 
 [tool.setuptools]
-packages = ["flexparser"]
+packages = ["flexparser", "flexparser.testsuite"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [X] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [X] Added an entry to the CHANGES file

When I build the package in debian sid I get the following warning:

```
/usr/lib/python3/dist-packages/setuptools/command/build_py.py:215: _Warning: Package 'flexparser.testsuite' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'flexparser.testsuite' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'flexparser.testsuite' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'flexparser.testsuite' to be distributed and are
        already explicitly excluding 'flexparser.testsuite' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
```

This PR fixes the warning.