### PR TITLE
Remove spurious test dependencies

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,2 @@
 pytest
-pytest-mpl
 pytest-cov
-pytest-subtests


### PR DESCRIPTION
Remove `pytest-mpl` and `pytest-subtests` from `requirements.test.txt` because they are not actually used.

- [ ] Closes # (insert issue number) **N/A*
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Added an entry to the CHANGES file **N/A – is this too trivial to record there?**
